### PR TITLE
Improve assert error messages + minor cleanup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+# This is an example .flake8 config, used when developing *Black* itself.
+# Keep in sync with setup.cfg which is used for source packages.
+
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="yacs",
-    version="0.1.2",
+    version="0.1.3",
     author="Ross Girshick",
     author_email="ross.girshick@gmail.com",
     description="Yet Another Configuration System",
@@ -17,7 +17,5 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
-    install_requires=[
-        "PyYAML",
-    ],
+    install_requires=["PyYAML"],
 )

--- a/yacs/config.py
+++ b/yacs/config.py
@@ -286,7 +286,7 @@ def _valid_type(value, allow_cfg_node=False):
     return (type(value) in _VALID_TYPES) or (allow_cfg_node and type(value) == CfgNode)
 
 
-def _merge_a_into_b(a, b, root, stack):
+def _merge_a_into_b(a, b, root, key_list):
     """Merge config dictionary a into config dictionary b, clobbering the
     options in b whenever they are also specified in a.
     """
@@ -300,7 +300,7 @@ def _merge_a_into_b(a, b, root, stack):
     )
 
     for k, v_ in a.items():
-        full_key = ".".join(stack + [k])
+        full_key = ".".join(key_list + [k])
         # a must specify keys that are in b
         if k not in b:
             if root.key_is_deprecated(full_key):
@@ -317,7 +317,7 @@ def _merge_a_into_b(a, b, root, stack):
         # Recursively merge dicts
         if isinstance(v, CfgNode):
             try:
-                _merge_a_into_b(v, b[k], root, stack + [k])
+                _merge_a_into_b(v, b[k], root, key_list + [k])
             except BaseException:
                 raise
         else:

--- a/yacs/tests.py
+++ b/yacs/tests.py
@@ -6,7 +6,7 @@ import yacs.config
 from yacs.config import CfgNode as CN
 
 try:
-    _ignore = unicode
+    _ignore = unicode  # noqa: F821
     PY2 = True
 except Exception as _ignore:
     PY2 = False
@@ -119,7 +119,7 @@ class TestCfg(unittest.TestCase):
             cfg2 = CN()
             cfg2.A_UNICODE_KEY = b"bar"
             cfg.merge_from_other_cfg(cfg2)
-            assert type(cfg.A_UNICODE_KEY) == unicode
+            assert type(cfg.A_UNICODE_KEY) == unicode  # noqa: F821
             assert cfg.A_UNICODE_KEY == u"bar"
 
         # Test: merge with invalid type
@@ -169,6 +169,18 @@ class TestCfg(unittest.TestCase):
         with self.assertRaises(AttributeError):
             _ = cfg.MODEL.DILATION  # noqa
 
+    def test_nonexistant_key_from_list(self):
+        cfg = get_cfg()
+        opts = ["MODEL.DOES_NOT_EXIST", "IGNORE"]
+        with self.assertRaises(AssertionError):
+            cfg.merge_from_list(opts)
+
+    def test_load_cfg_invalid_type(self):
+        # FOO.BAR.QUUX will have type None, which is not allowed
+        cfg_string = "FOO:\n BAR:\n  QUUX:"
+        with self.assertRaises(AssertionError):
+            yacs.config.load_cfg(cfg_string)
+
     def test_deprecated_key_from_file(self):
         # You should see logger messages like:
         #   "Deprecated config key (ignoring): MODEL.DILATION"
@@ -214,4 +226,6 @@ class TestCfg(unittest.TestCase):
 
 if __name__ == "__main__":
     logging.basicConfig()
+    yacs_logger = logging.getLogger("yacs.config")
+    yacs_logger.setLevel(logging.DEBUG)
     unittest.main()


### PR DESCRIPTION
- Improves `assert` error messages
- Logs assert messages at `DEBUG` level so that when we trigger them in unit tests we can visually verify message correctness
- Minor cleanup regarding how full key names are tracked