### PR TITLE
Add __str__ and __repr__ methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ the `cfg` can be copied and passed as an argument.
 
 ```python
 # my_project/main.py
-import pprint
 
 import my_project
 from config import cfg
@@ -61,7 +60,7 @@ from config import cfg
 if __name__ == "__main__":
   cfg.merge_from_file("experiment.yaml")
   cfg.freeze()
-  pprint.pprint(cfg)
+  print(cfg)
 
   # Example of using the cfg as global access to options
   if cfg.SYSTEM.NUM_GPUS > 0:

--- a/example/main.py
+++ b/example/main.py
@@ -1,5 +1,3 @@
-import pprint
-
 from config import cfg
 
 if __name__ == "__main__":
@@ -12,6 +10,6 @@ if __name__ == "__main__":
     cfg2.freeze()
 
     print("cfg:")
-    pprint.pprint(cfg)
+    print(cfg)
     print("cfg2:")
-    pprint.pprint(cfg2)
+    print(cfg2)

--- a/yacs/config.py
+++ b/yacs/config.py
@@ -104,6 +104,30 @@ class CfgNode(dict):
 
         self[name] = value
 
+    def __str__(self):
+        def _indent(s_, num_spaces):
+            s = s_.split("\n")
+            if len(s) == 1:
+                return s_
+            first = s.pop(0)
+            s = [(num_spaces * " ") + line for line in s]
+            s = "\n".join(s)
+            s = first + "\n" + s
+            return s
+
+        r = ""
+        s = []
+        for k, v in sorted(self.items()):
+            seperator = "\n" if isinstance(v, CfgNode) else " "
+            attr_str = "{}:{}{}".format(str(k), seperator, str(v))
+            attr_str = _indent(attr_str, 2)
+            s.append(attr_str)
+        r += "\n".join(s)
+        return r
+
+    def __repr__(self):
+        return "{}({})".format(self.__class__.__name__, super(CfgNode, self).__repr__())
+
     def dump(self):
         """Dump to a string."""
         self_as_dict = _to_dict(self)

--- a/yacs/tests.py
+++ b/yacs/tests.py
@@ -24,6 +24,17 @@ def get_cfg():
     cfg.MODEL = CN()
     cfg.MODEL.TYPE = "a_foo_model"
 
+    # Some extra stuff to test CfgNode.__str__
+    cfg.STR = CN()
+    cfg.STR.KEY1 = 1
+    cfg.STR.KEY2 = 2
+    cfg.STR.FOO = CN()
+    cfg.STR.FOO.KEY1 = 1
+    cfg.STR.FOO.KEY2 = 2
+    cfg.STR.FOO.BAR = CN()
+    cfg.STR.FOO.BAR.KEY1 = 1
+    cfg.STR.FOO.BAR.KEY2 = 2
+
     cfg.register_deprecated_key("FINAL_MSG")
     cfg.register_deprecated_key("MODEL.DILATION")
 
@@ -228,4 +239,6 @@ if __name__ == "__main__":
     logging.basicConfig()
     yacs_logger = logging.getLogger("yacs.config")
     yacs_logger.setLevel(logging.DEBUG)
+    yacs_logger.debug("\n" + str(get_cfg()))
+    yacs_logger.debug("\n" + repr(get_cfg()))
     unittest.main()

--- a/yacs/tests.py
+++ b/yacs/tests.py
@@ -234,11 +234,35 @@ class TestCfg(unittest.TestCase):
         with self.assertRaises(AssertionError):
             cfg.INVALID_KEY_TYPE = object()
 
+    def test__str__(self):
+        expected_str = """
+MODEL:
+  TYPE: a_foo_model
+NUM_GPUS: 8
+STR:
+  FOO:
+    BAR:
+      KEY1: 1
+      KEY2: 2
+    KEY1: 1
+    KEY2: 2
+  KEY1: 1
+  KEY2: 2
+TRAIN:
+  HYPERPARAMETER_1: 0.1
+  SCALES: (2, 4, 8, 16)
+""".strip()
+        cfg = get_cfg()
+        assert str(cfg) == expected_str
+
+    def test__repr__(self):
+        expected_str = "CfgNode({'NUM_GPUS': 8, 'TRAIN': CfgNode({'HYPERPARAMETER_1': 0.1, 'SCALES': (2, 4, 8, 16)}), 'MODEL': CfgNode({'TYPE': 'a_foo_model'}), 'STR': CfgNode({'KEY1': 1, 'KEY2': 2, 'FOO': CfgNode({'KEY1': 1, 'KEY2': 2, 'BAR': CfgNode({'KEY1': 1, 'KEY2': 2})})})})"  # noqa B950
+        cfg = get_cfg()
+        assert repr(cfg) == expected_str
+
 
 if __name__ == "__main__":
     logging.basicConfig()
     yacs_logger = logging.getLogger("yacs.config")
     yacs_logger.setLevel(logging.DEBUG)
-    yacs_logger.debug("\n" + str(get_cfg()))
-    yacs_logger.debug("\n" + repr(get_cfg()))
     unittest.main()


### PR DESCRIPTION
Addresses #3 by adding `CfgNode.__str__`. From my understanding of `__repr__` vs. `__str__`, it's best to leave `__repr__` as a dictionary serialization of the `CfgNode` so that a `CfgNode` can be constructed directly from it. The `__str__` version is meant to be a nice to read. The test now prints a sample, which looks like this:

```yaml
MODEL:
  TYPE: a_foo_model
NUM_GPUS: 8
STR:
  FOO:
    BAR:
      KEY1: 1
      KEY2: 2
    KEY1: 1
    KEY2: 2
  KEY1: 1
  KEY2: 2
TRAIN:
  HYPERPARAMETER_1: 0.1
  SCALES: (2, 4, 8, 16)
```

The provided `__repr__` implementation will output:

```py
CfgNode({'NUM_GPUS': 8, 'TRAIN': CfgNode({'HYPERPARAMETER_1': 0.1, 'SCALES': (2, 4, 8, 16)}), 'MODEL': CfgNode({'TYPE': 'a_foo_model'}), 'STR': CfgNode({'KEY1': 1, 'KEY2': 2, 'FOO': CfgNode({'KEY1': 1, 'KEY2': 2, 'BAR': CfgNode({'KEY1': 1, 'KEY2': 2})})})})
```

If `CfgNode` is imported, this string can be `eval()`'d to produce the corresponding config object.