### PR TITLE
Expose safe_dump's kwargs

### DIFF
--- a/yacs/config.py
+++ b/yacs/config.py
@@ -162,10 +162,10 @@ class CfgNode(dict):
     def __repr__(self):
         return "{}({})".format(self.__class__.__name__, super(CfgNode, self).__repr__())
 
-    def dump(self):
+    def dump(self, **kwargs):
         """Dump to a string."""
         self_as_dict = _to_dict(self)
-        return yaml.safe_dump(self_as_dict)
+        return yaml.safe_dump(self_as_dict, **kwargs)
 
     def merge_from_file(self, cfg_filename):
         """Load a yaml config file and merge it this CfgNode."""


### PR DESCRIPTION
Thanks for sharing the code! This is just a _cosmetic_ PR, if you don't mind. Some people (including me :smile: ) may prefer using the _block style_ when dumping, which requires `default_flow_style=False`. Exposing `**kwargs` also provides the full `safe_dump` functionality (full list of dump's arguments can be seen [here](https://pyyaml.org/wiki/PyYAMLDocumentation#cb67%2D7)) that may be useful, eventually. Of course the user could do this without using the `dump()`, but AFAIK it would "require" using `_to_dict()` which is not supposed to be used (on the public API).

    