### PR TITLE
Add a support display for NoneType

### DIFF
--- a/yacs/config.py
+++ b/yacs/config.py
@@ -490,8 +490,9 @@ def _check_and_coerce_cfg_value_type(replacement, original, key, full_key):
         return replacement
 
     # If either of them is None, allow type conversion to one of the valid types
-    if (replacement_type == type(None) and original_type in _VALID_TYPES) \
-            or (original_type == type(None) and replacement_type in _VALID_TYPES):
+    if (replacement_type == type(None) and original_type in _VALID_TYPES) or (
+        original_type == type(None) and replacement_type in _VALID_TYPES
+    ):
         return replacement
 
     # Cast replacement from from_type to to_type if the replacement and original

--- a/yacs/config.py
+++ b/yacs/config.py
@@ -45,7 +45,7 @@ else:
     _FILE_TYPES = (io.IOBase,)
 
 # CfgNodes can only contain a limited set of valid types
-_VALID_TYPES = {tuple, list, str, int, float, bool}
+_VALID_TYPES = {tuple, list, str, int, float, bool, type(None)}
 # py2 allow for str and unicode
 if _PY2:
     _VALID_TYPES = _VALID_TYPES.union({unicode})  # noqa: F821

--- a/yacs/config.py
+++ b/yacs/config.py
@@ -485,6 +485,11 @@ def _check_and_coerce_cfg_value_type(replacement, original, key, full_key):
     if replacement_type == original_type:
         return replacement
 
+    # If either of them is None, allow type conversion to one of the valid types
+    if (replacement_type == type(None) and original_type in _VALID_TYPES) \
+            or (original_type == type(None) and replacement_type in _VALID_TYPES):
+        return replacement
+
     # Cast replacement from from_type to to_type if the replacement and original
     # types match from_type and to_type
     def conditional_cast(from_type, to_type):

--- a/yacs/tests.py
+++ b/yacs/tests.py
@@ -1,9 +1,9 @@
 import logging
 import tempfile
 import unittest
-import yaml
 
 import yacs.config
+import yaml
 from yacs.config import CfgNode as CN
 
 try:
@@ -198,9 +198,10 @@ class TestCfg(unittest.TestCase):
 
     def test_load_cfg_invalid_type(self):
         class CustomClass(yaml.YAMLObject):
-              """A custom class that yaml.safe_load can load."""
-              yaml_loader = yaml.SafeLoader
-              yaml_tag = u'!CustomClass'
+            """A custom class that yaml.safe_load can load."""
+
+            yaml_loader = yaml.SafeLoader
+            yaml_tag = u"!CustomClass"
 
         # FOO.BAR.QUUX will have type CustomClass, which is not allowed
         cfg_string = "FOO:\n BAR:\n  QUUX: !CustomClass {}"

--- a/yacs/tests.py
+++ b/yacs/tests.py
@@ -1,6 +1,7 @@
 import logging
 import tempfile
 import unittest
+import yaml
 
 import yacs.config
 from yacs.config import CfgNode as CN
@@ -196,8 +197,13 @@ class TestCfg(unittest.TestCase):
             cfg.merge_from_list(opts)
 
     def test_load_cfg_invalid_type(self):
-        # FOO.BAR.QUUX will have type None, which is not allowed
-        cfg_string = "FOO:\n BAR:\n  QUUX:"
+        class CustomClass(yaml.YAMLObject):
+              """A custom class that yaml.safe_load can load."""
+              yaml_loader = yaml.SafeLoader
+              yaml_tag = u'!CustomClass'
+
+        # FOO.BAR.QUUX will have type CustomClass, which is not allowed
+        cfg_string = "FOO:\n BAR:\n  QUUX: !CustomClass {}"
         with self.assertRaises(AssertionError):
             yacs.config.load_cfg(cfg_string)
 


### PR DESCRIPTION
Hi,
Thanks for the works making configuration easily. But in my situation, some values could be NoneType as a kind of flag to control the program, or it could also be appeared in the config file.
e.g. a simple config.yaml:
```yaml
INFO:
  NAME: example
  DIR: null
```
As I expected to control it by:
```python
if _C.INFO.DIR is None:
  something
```
And I expected that the program prints it by calling `print(cfgNode)`
```bash
INFO:
  NAME: example
  DIR: None
```

Thanks,
KJ