### PR TITLE
Fixing example import statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ the `cfg` can be copied and passed as an argument.
 # my_project/main.py
 
 import my_project
-from config import get_cfg  # local variable usage pattern, or:
+from config import get_cfg_defaults  # local variable usage pattern, or:
 # from config import cfg  # global singleton usage pattern
 
 


### PR DESCRIPTION
Changing the import statement in the example main.py file to use the correct function name defined in the example config.py file