### PR TITLE
Allow all `yaml.safe_{load, dump}` types

### DIFF
--- a/example/config_types.yaml
+++ b/example/config_types.yaml
@@ -1,0 +1,14 @@
+NONE: null
+BOOL: True
+INT: 42
+FLOAT: 3.14
+BINARY: !!binary YmluYXJ5
+DATE: 2020-03-05
+DATETIME: 2020-03-05T13:07:56Z
+PAIRS: !!pairs [ one: 1, two: 2 ]
+SET: !!set {1,2,3}
+STRING: hello
+# Check None overwrite
+STR_NONE: hello
+# Check overwrite by None
+NONE_STR: null

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="yacs",
-    version="0.1.6",
+    version="0.2.0",
     author="Ross Girshick",
     author_email="ross.girshick@gmail.com",
     description="Yet Another Configuration System",

--- a/yacs/config.py
+++ b/yacs/config.py
@@ -21,6 +21,7 @@ See README.md for usage and examples.
 """
 
 import copy
+import datetime
 import io
 import logging
 import os
@@ -45,10 +46,12 @@ else:
     _FILE_TYPES = (io.IOBase,)
 
 # CfgNodes can only contain a limited set of valid types
-_VALID_TYPES = {tuple, list, str, int, float, bool}
-# py2 allow for str and unicode
+_VALID_TYPES = {tuple, list, str, int, float, bool, datetime.date, datetime.datetime, set, type(None)}
+# py2 allow for str, unicode and long
 if _PY2:
-    _VALID_TYPES = _VALID_TYPES.union({unicode})  # noqa: F821
+    _VALID_TYPES = _VALID_TYPES.union({unicode, long})  # noqa: F821
+else:
+    _VALID_TYPES = _VALID_TYPES.union({bytes})
 
 # Utilities for importing modules from file paths
 if _PY2:
@@ -433,7 +436,7 @@ load_cfg = (
 
 def _valid_type(value, allow_cfg_node=False):
     return (type(value) in _VALID_TYPES) or (
-        allow_cfg_node and isinstance(value, CfgNode)
+            allow_cfg_node and isinstance(value, CfgNode)
     )
 
 
@@ -482,6 +485,9 @@ def _check_and_coerce_cfg_value_type(replacement, original, key, full_key):
     the right type. The type is correct if it matches exactly or is one of a few
     cases in which the type can be easily coerced.
     """
+    if original is None or replacement is None:
+        return replacement
+
     original_type = type(original)
     replacement_type = type(replacement)
 

--- a/yacs/config.py
+++ b/yacs/config.py
@@ -436,7 +436,7 @@ load_cfg = (
 
 def _valid_type(value, allow_cfg_node=False):
     return (type(value) in _VALID_TYPES) or (
-            allow_cfg_node and isinstance(value, CfgNode)
+        allow_cfg_node and isinstance(value, CfgNode)
     )
 
 

--- a/yacs/config.py
+++ b/yacs/config.py
@@ -47,9 +47,10 @@ else:
 
 # CfgNodes can only contain a limited set of valid types
 _VALID_TYPES = {tuple, list, str, int, float, bool, datetime.date, datetime.datetime, set, type(None)}
-# py2 allow for str, unicode and long
+# py2 allow for unicode and long
 if _PY2:
     _VALID_TYPES = _VALID_TYPES.union({unicode, long})  # noqa: F821
+# py3 allow for bytes (py2 str)
 else:
     _VALID_TYPES = _VALID_TYPES.union({bytes})
 

--- a/yacs/tests.py
+++ b/yacs/tests.py
@@ -1,6 +1,7 @@
 import logging
 import tempfile
 import unittest
+from datetime import date, datetime
 
 import yacs.config
 from yacs.config import CfgNode as CN
@@ -195,12 +196,6 @@ class TestCfg(unittest.TestCase):
         with self.assertRaises(AssertionError):
             cfg.merge_from_list(opts)
 
-    def test_load_cfg_invalid_type(self):
-        # FOO.BAR.QUUX will have type None, which is not allowed
-        cfg_string = "FOO:\n BAR:\n  QUUX:"
-        with self.assertRaises(AssertionError):
-            yacs.config.load_cfg(cfg_string)
-
     def test_deprecated_key_from_file(self):
         # You should see logger messages like:
         #   "Deprecated config key (ignoring): MODEL.DILATION"
@@ -297,6 +292,23 @@ TRAIN:
         cfg = get_cfg()
         with self.assertRaises(KeyError):
             cfg.merge_from_file("example/config_new_allowed_bad.yaml")
+
+    def test_all_types(self):
+        cfg = CN()
+        cfg.NONE = None
+        cfg.BOOL = False
+        cfg.INT = 0
+        cfg.FLOAT = 2.72
+        cfg.BINARY = b"binary"
+        cfg.DATE = date(2020, 1, 1)
+        cfg.DATETIME = datetime(2020, 1, 1, 0, 0, 1)
+        cfg.PAIRS = [("zero", 0)]
+        cfg.SET = {1, }
+        cfg.STRING = "string"
+        cfg.STR_NONE = None
+        cfg.NONE_STR = "string"
+
+        cfg.merge_from_file("example/config_types.yaml")
 
 
 class TestCfgNodeSubclass(unittest.TestCase):


### PR DESCRIPTION
Fixes #11 

Since, this removes one of the tests, I think it warrants a minor version change.