### PR TITLE
Decode values when we want to add new CfgNode from yaml

### DIFF
--- a/example/config_new_allowed_cfg.yaml
+++ b/example/config_new_allowed_cfg.yaml
@@ -1,0 +1,7 @@
+KWARGS:
+  X:
+    a: 1e-3 # Test adding of 1e? type float value
+  Y:
+    b: [I, am, a, test]  # Test adding of a list of str
+    c:
+      d: [1, 3, 5, 7]  # Test adding of a list of integar

--- a/yacs/config.py
+++ b/yacs/config.py
@@ -481,7 +481,14 @@ def _merge_a_into_b(a, b, root, key_list):
             else:
                 b[k] = v
         elif b.is_new_allowed():
-            b[k] = v
+            if isinstance(v, CfgNode):
+                b[k] = CfgNode(new_allowed=True)
+                try:
+                    _merge_a_into_b(v, b[k], root, key_list + [k])
+                except BaseException:
+                    raise
+            else:
+                b[k] = v
         else:
             if root.key_is_deprecated(full_key):
                 continue


### PR DESCRIPTION
We find that when we want to add a new CfgNode from .yaml, it doesn't decode values of the new CfgNode. So we just fix this bug.