### PR TITLE
Add `diff_from(self, other)` method to CfgNode

### DIFF
--- a/yacs/config.py
+++ b/yacs/config.py
@@ -270,6 +270,22 @@ class CfgNode(dict):
             if isinstance(v, CfgNode):
                 v._immutable(is_immutable)
 
+    def diff_from(self, other):
+        out = CfgNode()
+        return self._diff_from(other, out)
+
+    def _diff_from(self, other, out):
+        for key in other.keys():
+            if key not in self.keys():
+                out[key] = other[key]
+            elif self[key] != other[key]:
+                if isinstance(other[key], CfgNode):
+                    out[key] = CfgNode()
+                    out[key] = self[key]._diff_from(other[key], out[key])
+                else:
+                    out[key] = other[key]
+        return out
+
     def clone(self):
         """Recursively copy this CfgNode."""
         return copy.deepcopy(self)
@@ -447,7 +463,7 @@ load_cfg = (
 
 def _valid_type(value, allow_cfg_node=False):
     return (type(value) in _VALID_TYPES) or (
-        allow_cfg_node and isinstance(value, CfgNode)
+            allow_cfg_node and isinstance(value, CfgNode)
     )
 
 
@@ -505,7 +521,7 @@ def _check_and_coerce_cfg_value_type(replacement, original, key, full_key):
 
     # If either of them is None, allow type conversion to one of the valid types
     if (replacement_type == type(None) and original_type in _VALID_TYPES) or (
-        original_type == type(None) and replacement_type in _VALID_TYPES
+            original_type == type(None) and replacement_type in _VALID_TYPES
     ):
         return replacement
 

--- a/yacs/config.py
+++ b/yacs/config.py
@@ -463,7 +463,7 @@ load_cfg = (
 
 def _valid_type(value, allow_cfg_node=False):
     return (type(value) in _VALID_TYPES) or (
-            allow_cfg_node and isinstance(value, CfgNode)
+        allow_cfg_node and isinstance(value, CfgNode)
     )
 
 
@@ -521,7 +521,7 @@ def _check_and_coerce_cfg_value_type(replacement, original, key, full_key):
 
     # If either of them is None, allow type conversion to one of the valid types
     if (replacement_type == type(None) and original_type in _VALID_TYPES) or (
-            original_type == type(None) and replacement_type in _VALID_TYPES
+        original_type == type(None) and replacement_type in _VALID_TYPES
     ):
         return replacement
 

--- a/yacs/config.py
+++ b/yacs/config.py
@@ -272,16 +272,23 @@ class CfgNode(dict):
 
     def diff_from(self, other):
         out = CfgNode()
+        out["add"] = CfgNode()
+        out["minus"] = CfgNode()
+        out["change"] = CfgNode()
+
         return self._diff_from(other, out)
 
     def _diff_from(self, other, out):
+        for key in self.keys():
+            if key not in other.keys():
+                out.minus[key] = self[key]
         for key in other.keys():
             if key not in self.keys():
-                out[key] = other[key]
+                out.add[key] = other[key]
             elif self[key] != other[key]:
                 if isinstance(other[key], CfgNode):
-                    out[key] = CfgNode()
-                    out[key] = self[key]._diff_from(other[key], out[key])
+                    out.change[key] = CfgNode()
+                    out.change[key] = self[key]._diff_from(other[key], out.change[key])
                 else:
                     out[key] = other[key]
         return out

--- a/yacs/tests.py
+++ b/yacs/tests.py
@@ -257,10 +257,18 @@ class TestCfg(unittest.TestCase):
         # Test a change in config gives correct diff config
         cfg = get_cfg()
         cfg2 = cfg.clone()
+        cfg2.pop("NUM_GPUS")
         cfg2.MODEL.TYPE = "a_bar_model"
+        cfg2.TEST = "new_key"
         expected = CN()
-        expected.MODEL = CN()
-        expected.MODEL.TYPE = "a_bar_model"
+        expected["add"] = CN()
+        expected.add.TEST = "new_key"
+        expected["minus"] = CN()
+        expected.minus.NUM_GPUS = 8
+        expected["change"] = CN()
+        expected.change.MODEL = CN()
+        expected.change.MODEL.TYPE = "a_bar_model"
+        print(cfg.diff_from(cfg2))
         assert cfg.diff_from(cfg2) == expected
 
     def test_load_from_python_file(self):

--- a/yacs/tests.py
+++ b/yacs/tests.py
@@ -253,6 +253,16 @@ class TestCfg(unittest.TestCase):
             with open(f.name, "rt") as f_read:
                 yacs.config.load_cfg(f_read)
 
+    def test_diff_cfg(self):
+        # Test a change in config gives correct diff config
+        cfg = get_cfg()
+        cfg2 = cfg.clone()
+        cfg2.MODEL.TYPE = "a_bar_model"
+        expected = CN()
+        expected.MODEL = CN()
+        expected.MODEL.TYPE = "a_bar_model"
+        assert cfg.diff_from(cfg2) == expected
+
     def test_load_from_python_file(self):
         # Case 1: exports CfgNode
         cfg = get_cfg()


### PR DESCRIPTION
I needed this in my work and thought it would be cool to incorporate:

Given 2 CfgNodes:

## Cfg1:
```
SYSTEM:
  NUM_GPUS: 2
TRAIN:
  SCALES: (1, 2)
DATASETS:
  train_2017:
    17: 1
    18: 1
```

## Cfg2:
```
SYSTEM:
  NUM_GPUS: 2
TRAIN:
  SCALES: (4, 5, 8)
DATASETS:
  train_2017:
    17: 1
    18: 1
```

calling `cfg1.diff_from(cfg2)` returns another `CfgNode` instance, which is the following:
```
add:
  
change:
  TRAIN:
    SCALES: (8, 16, 32)
minus:
  
```
